### PR TITLE
removed unused routing , removed unused relationships , changed text …

### DIFF
--- a/census_household.json
+++ b/census_household.json
@@ -115,7 +115,6 @@
                                     "title": "Information you need",
                                     "list": [
                                         "Names of the people living in household"
-                                       
                                     ]
                                 }
                             ]
@@ -217,7 +216,7 @@
                                 },
                                 {
                                     "goto": {
-                                        "block": "who-lives-here-completed"
+                                        "group": "who-lives-here-interstitial"
                                     }
                                 }
                             ]
@@ -301,96 +300,8 @@
                                 },
                                 {
                                     "goto": {
-                                        "block": "who-lives-here-completed"
+                                        "group": "who-lives-here-interstitial"
                                     }
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "id": "who-lives-here-relationship",
-                    "title": "Relationships",
-                    "hide_in_navigation": true,
-                    "routing_rules": [
-                        {
-                            "repeat": {
-                                "type": "answer_count_minus_one",
-                                "answer_id": "first-name"
-                            }
-                        }
-                    ],
-                    "blocks": [
-                        {
-                            "type": "Question",
-                            "id": "household-relationships",
-                            "questions": [
-                                {
-                                    "id": "household-relationships-question",
-                                    "title": "How are the following people related to {{ [answers['first-name'][group_instance], answers['last-name'][group_instance]] | format_household_name }}?",
-                                    "type": "Relationship",
-                                    "answers": [
-                                        {
-                                            "id": "household-relationships-answer",
-                                            "label": "%(other_person)s is %(current_person)s's",
-                                            "mandatory": false,
-                                            "options": [
-                                                {
-                                                    "label": "Husband or wife",
-                                                    "value": "Husband or wife"
-                                                },
-                                                {
-                                                    "label": "Same-sex civil partner",
-                                                    "value": "Same-sex civil partner"
-                                                },
-                                                {
-                                                    "label": "Partner",
-                                                    "value": "Partner"
-                                                },
-                                                {
-                                                    "label": "Son or daughter",
-                                                    "value": "Son or daughter"
-                                                },
-                                                {
-                                                    "label": "Step-child",
-                                                    "value": "Step-child"
-                                                },
-                                                {
-                                                    "label": "Brother or sister",
-                                                    "value": "Brother or sister"
-                                                },
-                                                {
-                                                    "label": "Step–brother or step–sister",
-                                                    "value": "Step–brother or step–sister"
-                                                },
-                                                {
-                                                    "label": "Mother or father",
-                                                    "value": "Mother or father"
-                                                },
-                                                {
-                                                    "label": "Step-mother or step-father",
-                                                    "value": "Step-mother or step-father"
-                                                },
-                                                {
-                                                    "label": "Grandchild",
-                                                    "value": "Grandchild"
-                                                },
-                                                {
-                                                    "label": "Grandparent",
-                                                    "value": "Grandparent"
-                                                },
-                                                {
-                                                    "label": "Relation - other",
-                                                    "value": "Relation - other"
-                                                },
-                                                {
-                                                    "label": "Unrelated (including foster child)",
-                                                    "value": "Unrelated (including foster child)"
-                                                }
-                                            ],
-                                            "type": "Relationship"
-                                        }
-                                    ]
                                 }
                             ]
                         }
@@ -618,18 +529,6 @@
                             "routing_rules": [
                                 {
                                     "goto": {
-                                        "block": "date-of-birth",
-                                        "when": [
-                                            {
-                                                "id": "over-16-answer",
-                                                "condition": "equals",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
                                         "block": "date-of-birth"
                                     }
                                 }
@@ -663,18 +562,6 @@
                                 }
                             ],
                             "routing_rules": [
-                                {
-                                    "goto": {
-                                        "block": "date-of-birth1",
-                                        "when": [
-                                            {
-                                                "id": "over-16-answer1",
-                                                "condition": "equals",
-                                                "value": "No"
-                                            }
-                                        ]
-                                    }
-                                },
                                 {
                                     "goto": {
                                         "block": "date-of-birth1"
@@ -772,18 +659,6 @@
                             "routing_rules": [
                                 {
                                     "goto": {
-                                        "block": "confirm-dob",
-                                        "when": [
-                                            {
-                                                "id": "date-of-birth",
-                                                "condition": "equals",
-                                                "value": "Male"
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "goto": {
                                         "block": "confirm-dob"
                                     }
                                 }
@@ -849,7 +724,7 @@
                                             {
                                                 "id": "confirm-date-of-birth-answer",
                                                 "condition": "equals",
-                                                "value": "No, I need to amend this date"
+                                                "value": "No, I need to change this date"
                                             }
                                         ]
                                     }
@@ -1716,7 +1591,6 @@
                                             ],
                                             "type": "Radio"
                                         }
-
                                     ]
                                 }
                             ],
@@ -3032,7 +2906,6 @@
                                 }
                             ]
                         },
-                        
                         {
                             "type": "Question",
                             "id": "professional-quals-proxy",


### PR DESCRIPTION
census armed forces test was falling over (500) with more than one user.  ( This led to an additional ticket on the backlog as it points to validator issues) 

Changes: 
Routing was attempting to go to a block in a different group , changed to go to the group and the target block was the first anyway,
relationship questions taken out
several cases of a when followed by another goto to the same target were removed (date of birth, date of birth1 and confirm dob)
Changed text on confirm date of birth answer so that it would match.

To test:- Run using quick launcher and validate that it supports multiple respondents and that routing works as expected